### PR TITLE
Removed the need for the cardano-cli to generate a keypair in the hello-world example

### DIFF
--- a/src/pages/getting-started/hello-world.mdx
+++ b/src/pages/getting-started/hello-world.mdx
@@ -118,27 +118,31 @@ Let's see it in action!
 
 ## Getting funds
 
-Before moving one, we'll need some funds, and a public/private key pair to hold them. We can generate a private key using `Lucid`:
+Before moving one, we'll need some funds, and a public/private key pair to hold them. We can generate a private key and an address using `Lucid`:
 
-```ts
+```ts filename="deno repl --allow-net --allow-write"
 import { Lucid } from "https://deno.land/x/lucid@0.8.3/mod.ts";
 
-console.log((await Lucid.new()).utils.generatePrivateKey());
+const lucid = await Lucid.new(undefined, "Preview");
+
+const privateKey = lucid.utils.generatePrivateKey();
+await Deno.writeTextFile("key.sk", privateKey);
+
+const address = await lucid.selectWalletFromPrivateKey(privateKey).wallet.address();
+await Deno.writeTextFile("key.addr", address);
 ```
 
-Store that private key and then, we'll need to make an address from the private key to receive some test funds from the faucet:
+<Callout>
+  You can run the instructions above in Deno's interactive REPL; just run:
 
-```ts
-console.log(
-  await (await Lucid.new(undefined, "Preview"))
-    .selectWalletFromPrivateKey(
-      "<private_key>",
-    )
-    .wallet.address(),
-);
-```
+  ```
+  deno repl --allow-net --allow-write
+  ```
 
-This outputs an address for the `preview` test network. Now, we can head to [the Cardano faucet](https://docs.cardano.org/cardano-testnet/tools/faucet) to get some funds on the preview network to our newly created address. Make sure to select _"Preview Testnet"_ as network.
+  and type/copy each line.
+</Callout>
+
+Now, we can head to [the Cardano faucet](https://docs.cardano.org/cardano-testnet/tools/faucet) to get some funds on the preview network to our newly created address (inside `key.addr`). Make sure to select _"Preview Testnet"_ as network.
 
 Using [CardanoScan](https://preview.cardanoscan.io/) we can watch for the faucet sending some ADA our way. This should be pretty fast.
 
@@ -178,10 +182,9 @@ const lucid = await Lucid.new(
   "Preview",
 );
 
-lucid.selectWalletFromPrivateKey("<private_key>");
+lucid.selectWalletFromPrivateKey(await Deno.readTextFile("./key.sk"));
 
 const validator = await readValidator("./assets/hello_world/spend/script.cbor");
-
 
 // --- Supporting functions
 
@@ -215,7 +218,6 @@ async function readValidator(filepath: String): Promise<SpendingValidator> {
   ├── hello_world.ts
   ├── key.addr
   ├── key.sk
-  ├── key.vk
   ├── lib
   │   └── ...
   └── validators
@@ -233,7 +235,12 @@ As value for that byte array, we provide a hash digest of our public key. This
 will be needed to unlock the funds.
 
 ```ts filename="hello-world.ts"
-const datum = Data.to(new Constr(0, [toHex(privateKey.to_public().hash().to_bytes())]));
+const publicKeyHash = lucid.utils
+  .getAddressDetails(await lucid.wallet.address())
+  .paymentCredential
+  .hash;
+
+const datum = Data.to(new Constr(0, [publicKeyHash]));
 
 const txLock = await lock(1000000, { into: validator, owner: datum });
 

--- a/src/pages/getting-started/hello-world.mdx
+++ b/src/pages/getting-started/hello-world.mdx
@@ -14,10 +14,6 @@ TypeScript (we recommend installing
 [deno](https://deno.land/manual@v1.29.1/getting_started/installation)) and have
 Aiken installed already.
 
-If you haven't any public/private key pair available, you'll also need the
-[`cardano-cli`](https://github.com/input-output-hk/cardano-node/tree/master/cardano-cli#cardano-cli)
-to generate some credentials.
-
 ## Scaffolding
 
 First, let's create a new `Aiken` project:
@@ -122,24 +118,27 @@ Let's see it in action!
 
 ## Getting funds
 
-Before moving one, we'll need some funds, and a public/private key pair to hold them. We can create a new keypair using the `cardano-cli` via:
+Before moving one, we'll need some funds, and a public/private key pair to hold them. We can generate a seed phrase using `Lucid` to create a new keypair:
 
-```
-cardano-cli address key-gen --normal-key \
-  --verification-key-file key.vk \
-  --signing-key-file key.sk
-```
+```ts
+import { Lucid } from "https://deno.land/x/lucid@0.8.3/mod.ts";
 
-Then, we'll need to make an address from our verification key to receive some test funds from the faucet. We can also use the `cardano-cli` for that:
-
-```
-cardano-cli address build \
-  --testnet-magic 2 \
-  --payment-verification-key-file key.vk \
-  > key.addr
+console.log((await Lucid.new()).utils.generateSeedPhrase());
 ```
 
-This creates an address for the `preview` test network, and stores it in `key.addr`. Now, we can head to [the Cardano faucet](https://docs.cardano.org/cardano-testnet/tools/faucet) to get some funds on the preview network to our newly created address. Make sure to select _"Preview Testnet"_ as network.
+Store that seed phrase and then, we'll need to make an address from the seed phrase to receive some test funds from the faucet:
+
+```ts
+console.log(
+  await (await Lucid.new(undefined, "Preview"))
+    .selectWalletFromSeed(
+      "<seed_phrase>",
+    )
+    .wallet.address(),
+);
+```
+
+This outputs an address for the `preview` test network. Now, we can head to [the Cardano faucet](https://docs.cardano.org/cardano-testnet/tools/faucet) to get some funds on the preview network to our newly created address. Make sure to select _"Preview Testnet"_ as network.
 
 Using [CardanoScan](https://preview.cardanoscan.io/) we can watch for the faucet sending some ADA our way. This should be pretty fast.
 
@@ -165,9 +164,9 @@ import {
   SpendingValidator,
   TxHash,
   fromHex,
-  fromhex,
   toHex,
-} from "https://deno.land/x/lucid@0.8.2/mod.ts";
+  utf8ToHex,
+} from "https://deno.land/x/lucid@0.8.3/mod.ts";
 import * as cbor from "https://deno.land/x/cbor@v1.4.1/index.js";
 
 
@@ -179,19 +178,12 @@ const lucid = await Lucid.new(
   "Preview",
 );
 
-const privateKey = await readPrivateKey("key.sk");
-
-lucid.selectWalletFromPrivateKey(privateKey.to_bech32());
+lucid.selectWalletFromSeed("<seed_phrase>");
 
 const validator = await readValidator("./assets/hello_world/spend/script.cbor");
 
 
 // --- Supporting functions
-
-async function readPrivateKey(filepath: String): Promise<C.PrivateKey> {
-  const str = JSON.parse(await Deno.readTextFile(filepath)).cborHex;
-  return C.PrivateKey.from_normal_bytes(fromHex(str.substr(4)));
-}
 
 async function readValidator(filepath: String): Promise<SpendingValidator> {
   return {
@@ -241,7 +233,7 @@ As value for that byte array, we provide a hash digest of our public key. This
 will be needed to unlock the funds.
 
 ```ts filename="hello-world.ts"
-const datum = Data.to(new Constr(0, [privateKey.to_public().hash().to_bytes()]));
+const datum = Data.to(new Constr(0, [toHex(privateKey.to_public().hash().to_bytes())]));
 
 const txLock = await lock(1000000, { into: validator, owner: datum });
 
@@ -304,7 +296,7 @@ To be valid, our transaction must meet two conditions:
 ```ts filename="hello-world.ts"
 const utxo = { txHash: txLock, outputIndex: 0 };
 
-const redeemer = Data.to(new Constr(0, [new TextEncoder().encode("Hello, World!")]));
+const redeemer = Data.to(new Constr(0, [utf8ToHex("Hello, World!")]));
 
 const txUnlock = await unlock(utxo, { from: validator, using: redeemer });
 

--- a/src/pages/getting-started/hello-world.mdx
+++ b/src/pages/getting-started/hello-world.mdx
@@ -118,21 +118,21 @@ Let's see it in action!
 
 ## Getting funds
 
-Before moving one, we'll need some funds, and a public/private key pair to hold them. We can generate a seed phrase using `Lucid` to create a new keypair:
+Before moving one, we'll need some funds, and a public/private key pair to hold them. We can generate a private key using `Lucid`:
 
 ```ts
 import { Lucid } from "https://deno.land/x/lucid@0.8.3/mod.ts";
 
-console.log((await Lucid.new()).utils.generateSeedPhrase());
+console.log((await Lucid.new()).utils.generatePrivateKey());
 ```
 
-Store that seed phrase and then, we'll need to make an address from the seed phrase to receive some test funds from the faucet:
+Store that private key and then, we'll need to make an address from the private key to receive some test funds from the faucet:
 
 ```ts
 console.log(
   await (await Lucid.new(undefined, "Preview"))
-    .selectWalletFromSeed(
-      "<seed_phrase>",
+    .selectWalletFromPrivateKey(
+      "<private_key>",
     )
     .wallet.address(),
 );
@@ -178,7 +178,7 @@ const lucid = await Lucid.new(
   "Preview",
 );
 
-lucid.selectWalletFromSeed("<seed_phrase>");
+lucid.selectWalletFromPrivateKey("<private_key>");
 
 const validator = await readValidator("./assets/hello_world/spend/script.cbor");
 


### PR DESCRIPTION
I'm not sure if this is desired, but I feel like the less prerequisites the better. Lucid itself can be used to generate key pairs. There are multiple ways. I used seed phrases now, which is probably the most convenient option.