### PR TITLE
fix argument of validFrom function to be of type `number`

### DIFF
--- a/src/pages/example--vesting.mdx
+++ b/src/pages/example--vesting.mdx
@@ -464,7 +464,7 @@ console.log(`1 ADA recovered from the contract
 // --- Supporting functions
 
 async function unlock(utxos, currentTime, { from, redeemer }): Promise<TxHash> {
-  const laterTime = new Date(currentTime + 2 * 60 * 60 * 1000); // add two hours (TTL: time to live)
+  const laterTime = new Date(currentTime + 2 * 60 * 60 * 1000).getTime(); // add two hours (TTL: time to live)
 
   const tx = await lucid
     .newTx()


### PR DESCRIPTION
[lucid](https://github.com/spacebudz/lucid/blob/733188340e5f972b4a67fb478bac2f87082e90ba/src/types/types.ts) expects the `validFrom` and `validTo` arguments to be of type number. The current example throws an error.
```javascript
/** Time in milliseconds */
export type UnixTime = number;
```
Ps. This was my last fix that prevented me from running the vesting example. Got the hello world and vesting to work. Great job!