### PR TITLE
Fix a few types on documentation examples

### DIFF
--- a/src/pages/language-tour/control-flow.mdx
+++ b/src/pages/language-tour/control-flow.mdx
@@ -82,13 +82,13 @@ particular, that the return types of both branches have to match.
 Incidentally, you can have as many conditional `else/if` branches as you need:
 
 ```aiken
-fn fibonnaci(n: Int) -> Int {
+fn fibonacci(n: Int) -> Int {
   if n == 0 {
     0
   } else if n == 1 {
     1
   } else {
-    fibonnaci(n-2) + fibonnaci(n-1)
+    fibonacci(n-2) + fibonacci(n-1)
   }
 }
 ```

--- a/src/pages/language-tour/custom-types.mdx
+++ b/src/pages/language-tour/custom-types.mdx
@@ -226,15 +226,15 @@ A type alias lets you create a name which is identical to
 another type, without any additional information.
 
 ```aiken
-type MyNumber = Integer
+type MyNumber = Int
 ```
 
 They are most useful for simplifying type signatures.
 
 ```aiken
-type Person = (String, Integer)
+type Person = (String, Int)
 
-fn create_person(name: String, age: Integer) -> Person {
+fn create_person(name: String, age: Int) -> Person {
   (name, age)
 }
 ```

--- a/src/pages/language-tour/functions.mdx
+++ b/src/pages/language-tour/functions.mdx
@@ -64,13 +64,13 @@ When calling the function, it is possible to use the defined labels to pass the
 arguments:
 
 ```aiken
-replace(self: "A,B,C", pattern: ",", replacement: " ")
+replace(self: @"A,B,C", pattern: @",", replacement: @" ")
 
 // Labeled arguments can be given in any order
-replace(pattern: ",", replacement: " ", self: "A,B,C")
+replace(pattern: @",", replacement: @" ", self: @"A,B,C")
 
 // Positional arguments and labels can be mixed
-replace("A,B,C", pattern: ",", replacement: " ")
+replace(@"A,B,C", pattern: @",", replacement: @" ")
 ```
 
 The use of argument labels can allow a function to be called in an expressive,


### PR DESCRIPTION
- Fixed: The `replace` function's arguments were defined as `String`s, but the function was applied to `ByteArray`s. 
- Fixed: Use of `Integer` instead of `Int` for the type aliases examples.
- Fixed typo: `fibonnaci` -> `fibonacci`