### PR TITLE
chore: align examples with latest formater

### DIFF
--- a/src/pages/example--hello-world/basics.mdx
+++ b/src/pages/example--hello-world/basics.mdx
@@ -102,15 +102,16 @@ validator hello_world {
     datum: Option<Datum>,
     redeemer: Redeemer,
     _own_ref: OutputReference,
-    self: Transaction
+    self: Transaction,
   ) {
     expect Some(Datum { owner }) = datum
-
     let must_say_hello = redeemer.msg == "Hello, World!"
-
     let must_be_signed = list.has(self.extra_signatories, owner)
-
     must_say_hello && must_be_signed
+  }
+
+  else(_) {
+    fail
   }
 }
 ```
@@ -170,6 +171,10 @@ validator hello_world {
 
     must_say_hello? && must_be_signed?
   }
+
+  else(_) {
+    fail
+  }
 }
 ```
 
@@ -192,17 +197,15 @@ test hello_world_example() {
   let datum =
     Datum { owner: #"00000000000000000000000000000000000000000000000000000000" }
 
-  let redeemer =
-    Redeemer { msg: "Aiken Rocks!" }
+  let redeemer = Redeemer { msg: "Aiken Rocks!" }
 
-  let placeholder_utxo =
-    OutputReference { transaction_id: "", output_index: 0 }
+  let placeholder_utxo = OutputReference { transaction_id: "", output_index: 0 }
 
   hello_world.spend(
     Some(datum),
     redeemer,
     placeholder_utxo,
-    transaction.placeholder
+    transaction.placeholder,
   )
 }
 ```
@@ -229,17 +232,15 @@ test hello_world_example() {
   let datum =
     Datum { owner: #"00000000000000000000000000000000000000000000000000000000" }
 
-  let redeemer =
-    Redeemer { msg: "Hello, World!" }
+  let redeemer = Redeemer { msg: "Hello, World!" }
 
-  let placeholder_utxo =
-    OutputReference { transaction_id: "", output_index: 0 }
+  let placeholder_utxo = OutputReference { transaction_id: "", output_index: 0 }
 
   hello_world.spend(
     Some(datum),
     redeemer,
     placeholder_utxo,
-    transaction.placeholder
+    transaction.placeholder,
   )
 }
 ```
@@ -266,20 +267,15 @@ test hello_world_example() {
   let datum =
     Datum { owner: #"00000000000000000000000000000000000000000000000000000000" }
 
-  let redeemer =
-    Redeemer { msg: "Hello, World!" }
+  let redeemer = Redeemer { msg: "Hello, World!" }
 
-  let placeholder_utxo =
-    OutputReference { transaction_id: "", output_index: 0 }
+  let placeholder_utxo = OutputReference { transaction_id: "", output_index: 0 }
 
   hello_world.spend(
     Some(datum),
     redeemer,
     placeholder_utxo,
-    Transaction {
-      ..transaction.placeholder,
-      extra_signatories: [datum.owner]
-    }
+    Transaction { ..transaction.placeholder, extra_signatories: [datum.owner] },
   )
 }
 ```


### PR DESCRIPTION
Make sure examples pass `aiken fmt --check`