### PR TITLE
Update vesting example doc

### DIFF
--- a/src/pages/example--vesting.mdx
+++ b/src/pages/example--vesting.mdx
@@ -35,14 +35,21 @@ Funds](/example--hello-world/end-to-end/lucid#getting-funds) in case you have an
 on the procedure.
 
 ```js filename="generate-credentials.mjs"
-import { MeshWallet } from '@meshsdk/core';
 import fs from 'node:fs';
+import 'dotenv/config';
+import {
+  MeshWallet,
+} from "@meshsdk/core";
 
-// Generate secret keys for both wallets
+
+// Generate a secret key for the owner wallet and beneficiary wallet
 const owner_secret_key = MeshWallet.brew(true);
 const beneficiary_secret_key = MeshWallet.brew(true);
 
-// Initialize the owner wallet with the generated secret key
+//Save secret keys to files
+fs.writeFileSync('owner.sk', owner_secret_key);
+fs.writeFileSync('beneficiary.sk', beneficiary_secret_key);
+
 const owner_wallet = new MeshWallet({
   networkId: 0,
   key: {
@@ -51,7 +58,6 @@ const owner_wallet = new MeshWallet({
   },
 });
 
-// Initialize the beneficiary wallet with its secret key, using the same setup
 const beneficiary_wallet = new MeshWallet({
   networkId: 0,
   key: {
@@ -60,15 +66,10 @@ const beneficiary_wallet = new MeshWallet({
   },
 });
 
-// save keys to files
-fs.writeFileSync('owner.sk', owner_secret_key);
-fs.writeFileSync('beneficiary.sk', beneficiary_secret_key);
-
 // Save unused addresses to files 
 fs.writeFileSync('owner.addr', owner_wallet.getUnusedAddresses()[0]);
 fs.writeFileSync('beneficiary.addr', beneficiary_wallet.getUnusedAddresses()[0]);
-</Callout>
-
+```
 
 ## On-Chain code
 
@@ -76,23 +77,14 @@ Let's write our time lock validator as `validators/vesting.ak`, starting with
 the definition of its interface (i.e. its datum's shape).
 
 ```aiken filename="validators/vesting.ak"
-use aiken/hash.{Blake2b_224, Hash}
-use aiken/transaction/credential.{VerificationKey}
-
-type Datum {
-  /// POSIX time in millisecond, e.g. 1672843961000
-  lock_until: POSIXTime,
+pub type VestingDatum {
+  /// POSIX time in milliseconds, e.g. 1672843961000
+  lock_until: Int,
   /// Owner's credentials
-  owner: VerificationKeyHash,
+  owner: ByteArray,
   /// Beneficiary's credentials
-  beneficiary: VerificationKeyHash,
+  beneficiary: ByteArray,
 }
-
-type VerificationKeyHash =
-  Hash<Blake2b_224, VerificationKey>
-
-type POSIXTime =
-  Int
 ```
 
 As we can see the script's datum serves as configuration and contains the
@@ -103,25 +95,31 @@ the conditions by which the funds can be released.
 From there, lets define the `spend` validator itself.
 
 ```aiken filename="validators/vesting.ak"
-use aiken/interval.{Finite}
-use aiken/list
-use aiken/transaction.{Transaction, ScriptContext, Spend, ValidityRange}
+use cardano/transaction.{OutputReference, Transaction}
+use vodka_extra_signatories.{key_signed}
+use vodka_validity_range.{valid_after}
 
-validator {
-  fn vesting(datum: Datum, _redeemer: Void, ctx: ScriptContext) {
+validator vesting {
+  spend(
+    datum_opt: Option<VestingDatum>,
+    _redeemer: Data,
+    _input: OutputReference,
+    tx: Transaction,
+  ) {
     // In principle, scripts can be used for different purpose (e.g. minting
     // assets). Here we make sure it's only used when 'spending' from a eUTxO
-    when ctx.purpose is {
-      Spend(_) ->
-        or {
-          must_be_signed_by(ctx.transaction, datum.owner),
-          and {
-            must_be_signed_by(ctx.transaction, datum.beneficiary),
-            must_start_after(ctx.transaction.validity_range, datum.lock_until),
-          },
-        }
-      _ -> False
+    expect Some(datum) = datum_opt
+    or {
+      key_signed(tx.extra_signatories, datum.owner),
+      and {
+        key_signed(tx.extra_signatories, datum.beneficiary),
+        valid_after(tx.validity_range, datum.lock_until),
+      },
     }
+  }
+
+  else(_) {
+    fail
   }
 }
 
@@ -201,140 +199,137 @@ Let's see the validator in action!
 
 ## Off-Chain code
 
-As a starter, we need to lock funds in our newly created contract. We'll use
-[`Lucid`](https://github.com/spacebudz/lucid) to construct and submit our
-transaction through Blockfrost.
-
-<Callout type="info">
-  This is only one example of possible setup using tools we love. For more
-  tools, make sure to check out the [Cardano Developer
-  Portal](https://developers.cardano.org/tools)!
-</Callout>
-
 ### Setup
+First, let's install the dotenv package(https://www.npmjs.com/package/dotenv), which allows us to import our API key from a .env file. Next, we'll create a directory called common and, within it, a file named common.mjs. 
+This file will house utility functions used for both locking and unlocking assets. In this setup, we will import our BLOCKFROST_API key from the .env file. 
 
-First, we setup Lucid with Blockfrost as a provider. You know the drill from
-the [_Hello, World!_](/getting-started/hello-world) example already.
 
-```ts filename="vesting_lock.ts"
+
+```js filename="common/common.mjs"
+import 'dotenv/config';
 import {
-  Blockfrost,
-  C,
-  Data,
-  Lucid,
-  SpendingValidator,
-  TxHash,
-  fromHex,
-  toHex,
-} from "https://deno.land/x/lucid@0.8.3/mod.ts";
-import * as cbor from "https://deno.land/x/cbor@v1.4.1/index.js";
+  MeshWallet,
+  BlockfrostProvider,
+  MeshTxBuilder,
+  serializePlutusScript,
+} from "@meshsdk/core";
+import { applyParamsToScript } from "@meshsdk/core-csl";
+import fs, { read } from 'fs';
 
-const lucid = await Lucid.new(
-  new Blockfrost(
-    "https://cardano-preview.blockfrost.io/api/v0",
-    Deno.env.get("BLOCKFROST_API_KEY"),
-  ),
-  "Preview",
-);
 
-lucid.selectWalletFromPrivateKey(await Deno.readTextFile("./owner.sk"));
+export const blockchainProvider = new BlockfrostProvider(process.env.BLOCKFROST_API);
 
-const validator = await readValidator();
 
-// --- Supporting functions
-
-async function readValidator(): Promise<SpendingValidator> {
-  const validator = JSON.parse(await Deno.readTextFile("plutus.json")).validators[0];
-  return {
-    type: "PlutusV2",
-    script: toHex(cbor.encode(fromHex(validator.compiledCode))),
-  };
-}
-```
-
-<Callout>
-  If you've installed [deno](https://deno.land/manual@v1.29.1/getting_started/installation), you can run the except above by executing:
-
-```
-deno run --allow-net --allow-read --allow-env vesting_lock.ts
-```
-
-It assumes that this file (`vesting_lock.ts`) is placed at the root of your `vesting` folder. At this stage, your folder should looks roughly like this:
-
-```
-./vesting
-│
-├── README.md
-├── aiken.toml
-├── plutus.json
-├── vesting_lock.ts
-├── owner.addr
-├── owner.sk
-├── beneficiary.addr
-├── beneficiary.sk
-├── lib
-│   └── ...
-└── validators
-    └── vesting.ak
-```
-
-</Callout>
-
-### Locking funds into the contract
-
-Here, we make our first transaction to lock funds into the contract. The datum
-must match the representation expected by the script, constructor is an object expecting 3 fields.
-
-```ts filename="vesting_lock.ts"
-const ownerPublicKeyHash = lucid.utils.getAddressDetails(
-  await lucid.wallet.address()
-).paymentCredential.hash;
-
-const beneficiaryPublicKeyHash =
-  lucid.utils.getAddressDetails(await Deno.readTextFile("beneficiary.addr"))
-    .paymentCredential.hash;
-
-const Datum = Data.Object({
-  lock_until: Data.BigInt, // this is POSIX time, you can check and set it here: https://www.unixtimestamp.com
-  owner: Data.String, // we can pass owner's verification key hash as byte array but also as a string
-  beneficiary: Data.String, // we can beneficiary's hash as byte array but also as a string
+export const owner_wallet = new MeshWallet({
+  networkId: 0,
+  fetcher: blockchainProvider,
+  submitter: blockchainProvider,
+  key: {
+    type: "root",
+    bech32: fs.readFileSync("owner.sk").toString(),
+  },
 });
 
-type Datum = Data.Static<typeof Datum>;
-
-const datum = Data.to<Datum>(
-  {
-    lock_until: 1672843961000n, // Wed Jan 04 2023 14:52:41 GMT+0000
-    owner: ownerPublicKeyHash, // our own wallet verification key hash
-    beneficiary: beneficiaryPublicKeyHash,
+export const beneficiary_wallet = new MeshWallet({
+  networkId: 0,
+  fetcher: blockchainProvider,
+  submitter: blockchainProvider,
+  key: {
+    type: "root",
+    bech32: fs.readFileSync("beneficiary.sk").toString(),
   },
-  Datum
-);
+});
 
-const txLock = await lock(1000000, { into: validator, datum: datum });
+export function getTxBuilder() {
+  return new MeshTxBuilder({
+    fetcher: blockchainProvider,
+    submitter: blockchainProvider,
+  });
+}
 
-await lucid.awaitTx(txLock);
+const blueprint = JSON.parse(fs.readFileSync("./plutus.json"));
+export const scriptCbor = applyParamsToScript(blueprint.validators[0].compiledCode, []);
+export const scriptAddr = serializePlutusScript(
+  { code: scriptCbor, version: "V3" },
+  undefined,
+  0
+).address;
 
-console.log(`1 tADA locked into the contract
-    Tx ID: ${txLock}
-    Datum: ${datum}
-`);
 
-// --- Supporting functions
+```
+### Locking funds into the contract
 
-async function lock(lovelace, { into, datum }): Promise<TxHash> {
-  const contractAddress = lucid.utils.validatorToAddress(into);
+First, we will set up the depositFundTx function.
+This function will encapsulate the core logic for locking funds into the smart contract, ensuring that the deposit process is handled efficiently and securely.
 
-  const tx = await lucid
-    .newTx()
-    .payToContract(contractAddress, { inline: datum }, { lovelace })
+```js filename="vesting_lock.mjs"
+import { mConStr0 } from "@meshsdk/common";
+import { deserializeAddress } from "@meshsdk/core";
+import {
+  getTxBuilder,
+  owner_wallet,
+  beneficiary_wallet,
+  scriptAddr,
+} from "./common/common.mjs";
+
+async function depositFundTx(amount, lockUntilTimeStampMs) {
+  const utxos = await owner_wallet.getUtxos();
+  const { pubKeyHash: ownerPubKeyHash } = deserializeAddress(
+    owner_wallet.addresses.baseAddressBech32
+  );
+  const { pubKeyHash: beneficiaryPubKeyHash } = deserializeAddress(
+    beneficiary_wallet.addresses.baseAddressBech32
+  );
+
+  const txBuilder = getTxBuilder();
+  await txBuilder
+    .txOut(scriptAddr, amount)
+    .txOutInlineDatumValue(
+      mConStr0([lockUntilTimeStampMs, ownerPubKeyHash, beneficiaryPubKeyHash])
+    )
+    .changeAddress(owner_wallet.addresses.baseAddressBech32)
+    .selectUtxosFrom(utxos)
     .complete();
-
-  const signedTx = await tx.sign().complete();
-
-  return signedTx.submit();
+  return txBuilder.txHex;
 }
 ```
+
+Now that we have built the core logic let's setup the main function that will handle signing and submitting the transaction. 
+It will also call depositFundTx with the arguments it expects. 
+
+```js filename="vesting_lock.mjs"
+
+// ^^^ Code above is unchanged. ^^^
+
+async function main() {
+  const assets = [
+    {
+      unit: "lovelace",
+      quantity: "3000000",
+    },
+  ];
+
+  const lockUntilTimeStamp = new Date();
+  lockUntilTimeStamp.setMinutes(lockUntilTimeStamp.getMinutes() + 1);
+
+  const unsignedTx = await depositFundTx(assets, lockUntilTimeStamp.getTime());
+
+  const signedTx = await owner_wallet.signTx(unsignedTx);
+  const txHash = await owner_wallet.submitTx(signedTx);
+  console.log("txHash", txHash);
+}
+
+main();
+```
+
+<Callout type="info">
+  You can run the instructions above using Node via:
+
+```console
+node vesting_lock.mjs
+```
+</Callout>
+
 
 ### Unlocking funds from the contract
 
@@ -491,6 +486,31 @@ async function unlock(utxos, currentTime, { from, using }): Promise<TxHash> {
 deno run --allow-net --allow-read --allow-env vesting_unlock.ts
 ```
 
+</Callout>
+
+<Callout>
+```
+This should be the projects structure. 
+./vesting
+│
+├── README.md
+├── aiken.toml
+└── common
+    └── common.mjs
+├── beneficiary.addr
+├── beneficiary.sk
+├── .env
+├── owner.addr
+├── owner.sk
+├── node_modules
+├── package.json
+├── package-lock.json
+├── plutus.json
+└── validators
+    └── vesting.ak
+├── vesting_lock.ts
+├── vesting_unlock.ts
+```
 </Callout>
 
 Assuming everything went well... congratulations 🎉!

--- a/src/pages/example--vesting.mdx
+++ b/src/pages/example--vesting.mdx
@@ -36,7 +36,7 @@ Funds](/example--hello-world/end-to-end/lucid#getting-funds) in case you have an
 on the procedure.
 
 
-```js filename="generate-credentials.mjs"
+```mjs filename="generate-credentials.mjs"
 import fs from 'node:fs';
 import 'dotenv/config';
 import {
@@ -140,17 +140,6 @@ validator vesting {
     fail
   }
 }
-
-fn must_be_signed_by(transaction: Transaction, vk: VerificationKeyHash) {
-  list.has(transaction.extra_signatories, vk)
-}
-
-fn must_start_after(range: ValidityRange, lock_expiration_time: POSIXTime) {
-  when range.lower_bound.bound_type is {
-    Finite(tx_earliest_time) -> lock_expiration_time <= tx_earliest_time
-    _ -> False
-  }
-}
 ```
 
 The novelty here mostly lies in the check against a time period. In fact,
@@ -223,7 +212,7 @@ This file will house utility functions used for both locking and unlocking asset
 
 
 
-```js filename="common/common.mjs"
+```mjs filename="common/common.mjs"
 import 'dotenv/config';
 import {
   MeshWallet,
@@ -367,9 +356,12 @@ To be valid, our transaction must meet one of two conditions:
 - It must be signed by the beneficiary, who is referenced as "beneficiary" in the datum, and the transaction must occur after a specific time threshold. 
   This threshold is defined as one minute beyond the current time when the lock condition is set.
 
-Let's make a new file `vesting_unlock.ts`. 
+Let's make a new file `vesting_unlock.ts` and add the bits to unlock the funds in the contract. 
+This file contains the function withdrawFundTx, which allows the beneficiary to unlock funds from a vesting contract. 
+The function handles the necessary transaction construction and ensures that the funds can only be accessed after the specified conditions are met.
 
-```ts filename="vesting_unlock.ts"
+
+```mjs filename="vesting_unlock.mjs"
 import {
   deserializeAddress,
   deserializeDatum,
@@ -432,16 +424,10 @@ async function withdrawFundTx(vestingUtxo) {
 }
 ```
 
-Now, let's add the bits to unlock the funds in the contract. We'll need the
-transaction identifier obtained when you ran the previous script
-(`vesting_lock.ts`)
+In this section, we define a `main` function that retrieves the transaction hash generated when we executed the `vesting_lock.mjs` file. 
+This hash will be used to fetch the corresponding UTxO (Unspent Transaction Output) for withdrawal.
 
-As we stated above, we need to make sure to only submit our transaction after
-the vesting delay has passed without what the node will simply reject the
-transaction (without charging any fee) and kindly ask us to re-submit the
-transaction at a later time.
-
-```ts filename="vesting_unlock.ts"
+```mjs filename="vesting_unlock.mjs"
 // ^^^ Code above is unchanged. ^^^
 
 async function main() {
@@ -475,7 +461,6 @@ main();
 
 <Callout>
   As you imagine, we can run this script with the following incantation:
-
 ```
 node vesting_unlock.mjs
 ```

--- a/src/pages/example--vesting.mdx
+++ b/src/pages/example--vesting.mdx
@@ -15,6 +15,7 @@ original owner.
 <br/>
 
 - [x] Writing non-trivial Aiken validators, with complex datums.
+- [x] Writing front-end transaction logic with Mesh.js
 - [x] Using more advanced Aiken features (type-aliases, pattern-matches)
 - [x] Writing unit tests using Aiken's built-in test framework
 - [x] Managing time on-chain through transaction validity ranges
@@ -33,6 +34,7 @@ faucet](https://docs.cardano.org/cardano-testnet/tools/faucet) to receive test
 funds. Refer to [Hello, World! :: Getting
 Funds](/example--hello-world/end-to-end/lucid#getting-funds) in case you have any doubts
 on the procedure.
+
 
 ```js filename="generate-credentials.mjs"
 import fs from 'node:fs';
@@ -70,7 +72,6 @@ const beneficiary_wallet = new MeshWallet({
 fs.writeFileSync('owner.addr', owner_wallet.getUnusedAddresses()[0]);
 fs.writeFileSync('beneficiary.addr', beneficiary_wallet.getUnusedAddresses()[0]);
 ```
-
 ## On-Chain code
 
 Let's write our time lock validator as `validators/vesting.ak`, starting with
@@ -86,6 +87,23 @@ pub type VestingDatum {
   beneficiary: ByteArray,
 }
 ```
+## Dependency
+An additional dependency we will add to this project is [Vodka](https://github.com/sidan-lab/vodka).
+To include vodka in our Aiken project, lets update our aiken.toml file to specify it as a dependency.
+
+```aiken filename="aiken.toml"
+[[dependencies]]
+name = "sidan-lab/vodka"
+version = "0.1.1-beta"
+source = "github"
+
+```
+Using Vodka as a dependency provides access to several utility functions designed for common contract validation needs. 
+In our vesting.ak file, we will use two specific functions from Vodka:
+
+- **`key_signed`**: Verifies that a specific key has signed the transaction. This ensures only authorized users can interact with the contract.
+
+- **`valid_after`**: Checks that a transaction is only valid after a designated time. This is useful for setting time-based constraints within your contract logic.
 
 As we can see the script's datum serves as configuration and contains the
 different parameters of our vesting operation. Remember that these elements are
@@ -316,6 +334,8 @@ async function main() {
 
   const signedTx = await owner_wallet.signTx(unsignedTx);
   const txHash = await owner_wallet.submitTx(signedTx);
+
+  //Copy this txHash. You will need this hash in vesting_unlock.mjs
   console.log("txHash", txHash);
 }
 
@@ -329,6 +349,9 @@ node vesting_lock.mjs
 ```
 </Callout>
 
+If all went according to plan, you should see the transaction identifier in the console.
+Make sure you copy this hash, you will need it in vestin_unlock.mjs file. 
+
 
 ### Unlocking funds from the contract
 
@@ -341,21 +364,10 @@ Finally, as a last step: we now want to spend the UTxO that is locked by our
 To be valid, our transaction must meet one of two conditions:
 
 - it must be signed by the owner referenced as "owner" in the datum; or
-- it must be signed by the beneficiary referenced as "beneficiary" in the datum
-  AND time has to pass beyond the threshold we fixed -- that is it needs to be
-  later than 'Wed Jan 04 2023 14:52:41 GMT+0000'.
+- It must be signed by the beneficiary, who is referenced as "beneficiary" in the datum, and the transaction must occur after a specific time threshold. 
+  This threshold is defined as one minute beyond the current time when the lock condition is set.
 
-Like for the _Hello, World!_ example, we need to explicitly add a signer using
-`.addSigner` so that it gets added to the `extra_signatories` of our
-transaction and becomes accessible for our script.
-
-In addition we need to specify `.validFrom` as a POSIX timestamp from where
-transaction is considered valid (should be by the time we submit it). We can
-optionally defined an upper validity bound using `.validTo` as a TTL
-(Time-To-Live).
-
-Let's make a new file `vesting_unlock.ts` and copy over some of the boilerplate
-from the first one.
+Let's make a new file `vesting_unlock.ts`. 
 
 ```ts filename="vesting_unlock.ts"
 import {
@@ -424,10 +436,6 @@ Now, let's add the bits to unlock the funds in the contract. We'll need the
 transaction identifier obtained when you ran the previous script
 (`vesting_lock.ts`)
 
-That transaction identifier, and the corresponding output index (here, `0`)
-uniquely identifies the UTxO (Unspent Transaction Output) in which the funds
-are currently locked. And that's the one we're about to unlock.
-
 As we stated above, we need to make sure to only submit our transaction after
 the vesting delay has passed without what the node will simply reject the
 transaction (without charging any fee) and kindly ask us to re-submit the
@@ -438,7 +446,7 @@ transaction at a later time.
 
 async function main() {
   const txHashFromDesposit =
-    //This is the hash of the tx that we want to unlock
+    //This is the hash that we generated in the locking file when we submitted the transaction.
     "ed7559c7aa5a8bfcba9ec8d75fb2ee1902da8b909722ca4726261d35e8250645";
 
   const utxo = await getUtxoByTxHash(txHashFromDesposit);

--- a/src/pages/example--vesting.mdx
+++ b/src/pages/example--vesting.mdx
@@ -34,7 +34,7 @@ funds. Refer to [Hello, World! :: Getting
 Funds](/example--hello-world/end-to-end/lucid#getting-funds) in case you have any doubts
 on the procedure.
 
-```js filename="generate-credentials.ts"
+```js filename="generate-credentials.mjs"
 import { MeshWallet } from '@meshsdk/core';
 import fs from 'node:fs';
 

--- a/src/pages/example--vesting.mdx
+++ b/src/pages/example--vesting.mdx
@@ -34,34 +34,39 @@ funds. Refer to [Hello, World! :: Getting
 Funds](/example--hello-world/end-to-end/lucid#getting-funds) in case you have any doubts
 on the procedure.
 
-```ts filename="generate-credentials.ts"
-import { Lucid } from "https://deno.land/x/lucid@0.8.3/mod.ts";
+```js filename="generate-credentials.ts"
+import { MeshWallet } from '@meshsdk/core';
+import fs from 'node:fs';
 
-const lucid = await Lucid.new(undefined, "Preview");
+// Generate secret keys for both wallets
+const owner_secret_key = MeshWallet.brew(true);
+const beneficiary_secret_key = MeshWallet.brew(true);
 
-const ownerPrivateKey = lucid.utils.generatePrivateKey();
-await Deno.writeTextFile("owner.sk", ownerPrivateKey);
+// Initialize the owner wallet with the generated secret key
+const owner_wallet = new MeshWallet({
+  networkId: 0,
+  key: {
+    type: 'root',
+    bech32: owner_secret_key,
+  },
+});
 
-const ownerAddress = await lucid
-  .selectWalletFromPrivateKey(ownerPrivateKey)
-  .wallet.address();
-await Deno.writeTextFile("owner.addr", ownerAddress);
+// Initialize the beneficiary wallet with its secret key, using the same setup
+const beneficiary_wallet = new MeshWallet({
+  networkId: 0,
+  key: {
+    type: 'root',
+    bech32: beneficiary_secret_key,
+  },
+});
 
-const beneficiaryPrivateKey = lucid.utils.generatePrivateKey();
-await Deno.writeTextFile("beneficiary.sk", beneficiaryPrivateKey);
+// save keys to files
+fs.writeFileSync('owner.sk', owner_secret_key);
+fs.writeFileSync('beneficiary.sk', beneficiary_secret_key);
 
-const beneficiaryAddress = await lucid
-  .selectWalletFromPrivateKey(beneficiaryPrivateKey)
-  .wallet.address();
-await Deno.writeTextFile("beneficiary.addr", beneficiaryAddress);
-```
-
-<Callout type="info">
-  You can run the instructions above using Deno via:
-
-```console
-deno run --allow-net --allow-write generate-credentials.ts
-```
+// Save unused addresses to files 
+fs.writeFileSync('owner.addr', owner_wallet.getUnusedAddresses()[0]);
+fs.writeFileSync('beneficiary.addr', beneficiary_wallet.getUnusedAddresses()[0]);
 </Callout>
 
 

--- a/src/pages/example--vesting.mdx
+++ b/src/pages/example--vesting.mdx
@@ -1,12 +1,5 @@
 import { Callout } from "nextra-theme-docs";
 
-<Callout type="warning">
-This **tutorial is outdated** and only works with `aiken==1.0.29-alpha`. It will
-eventually be updated to the latest version, and likely migrated to [Mesh](https://meshjs.dev) or [Blaze](https://github.com/butaneprotocol/blaze-cardano).
-
-Feel like helping? [Pull requests are much appreciated](https://github.com/aiken-lang/site/blob/main/src/pages/example--vesting.mdx)!
-</Callout>
-
 # Vesting
 
 Armed with our recently acquired knowledge from the _Hello, World!_ contract,

--- a/src/pages/example--vesting.mdx
+++ b/src/pages/example--vesting.mdx
@@ -322,9 +322,8 @@ async function main() {
 main();
 ```
 
-<Callout type="info">
+<Callout>
   You can run the instructions above using Node via:
-
 ```console
 node vesting_lock.mjs
 ```
@@ -360,41 +359,64 @@ from the first one.
 
 ```ts filename="vesting_unlock.ts"
 import {
-  Blockfrost,
-  C,
-  Data,
-  Lucid,
-  SpendingValidator,
-  TxHash,
-  fromHex,
-  toHex,
-} from "https://deno.land/x/lucid@0.8.3/mod.ts";
-import * as cbor from "https://deno.land/x/cbor@v1.4.1/index.js";
+  deserializeAddress,
+  deserializeDatum,
+  unixTimeToEnclosingSlot,
+  SLOT_CONFIG_NETWORK,
+} from "@meshsdk/core";
 
-const lucid = await Lucid.new(
-  new Blockfrost(
-    "https://cardano-preview.blockfrost.io/api/v0",
-    Deno.env.get("BLOCKFROST_API_KEY"),
-  ),
-  "Preview",
-);
+import {
+  getTxBuilder,
+  beneficiary_wallet,
+  scriptAddr,
+  scriptCbor,
+  blockchainProvider,
+} from "./common/common.mjs";
 
-lucid.selectWalletFromPrivateKey(await Deno.readTextFile("./beneficiary.sk"));
+async function withdrawFundTx(vestingUtxo) {
+  const utxos = await beneficiary_wallet.getUtxos();
+  const beneficiaryAddress = beneficiary_wallet.addresses.baseAddressBech32;
+  const collateral = await beneficiary_wallet.getCollateral();
+  const collateralInput = collateral[0].input;
+  const collateralOutput = collateral[0].output;
 
-const beneficiaryPublicKeyHash = lucid.utils.getAddressDetails(
-  await lucid.wallet.address()
-).paymentCredential.hash;
+  const { pubKeyHash: beneficiaryPubKeyHash } = deserializeAddress(
+    beneficiary_wallet.addresses.baseAddressBech32
+  );
 
-const validator = await readValidator();
+  const datum = deserializeDatum(vestingUtxo.output.plutusData);
 
-// --- Supporting functions
+  const invalidBefore =
+    unixTimeToEnclosingSlot(
+      Math.min(datum.fields[0].int, Date.now() - 19000),
+      SLOT_CONFIG_NETWORK.preview
+    ) + 1;
 
-async function readValidator(): Promise<SpendingValidator> {
-  const validator = JSON.parse(await Deno.readTextFile("plutus.json")).validators[0];
-  return {
-    type: "PlutusV2",
-    script: toHex(cbor.encode(fromHex(validator.compiledCode))),
-  };
+  const txBuilder = getTxBuilder();
+  await txBuilder
+    .spendingPlutusScript("V3")
+    .txIn(
+      vestingUtxo.input.txHash,
+      vestingUtxo.input.outputIndex,
+      vestingUtxo.output.amount,
+      scriptAddr
+    )
+    .spendingReferenceTxInInlineDatumPresent()
+    .spendingReferenceTxInRedeemerValue("")
+    .txInScript(scriptCbor)
+    .txOut(beneficiaryAddress, [])
+    .txInCollateral(
+      collateralInput.txHash,
+      collateralInput.outputIndex,
+      collateralOutput.amount,
+      collateralOutput.address
+    )
+    .invalidBefore(invalidBefore)
+    .requiredSignerHash(beneficiaryPubKeyHash)
+    .changeAddress(beneficiaryAddress)
+    .selectUtxosFrom(utxos)
+    .complete();
+  return txBuilder.txHex;
 }
 ```
 
@@ -414,68 +436,32 @@ transaction at a later time.
 ```ts filename="vesting_unlock.ts"
 // ^^^ Code above is unchanged. ^^^
 
-const scriptAddress = lucid.utils.validatorToAddress(validator);
+async function main() {
+  const txHashFromDesposit =
+    //This is the hash of the tx that we want to unlock
+    "ed7559c7aa5a8bfcba9ec8d75fb2ee1902da8b909722ca4726261d35e8250645";
 
-// we get all the UTXOs sitting at the script address
-const scriptUtxos = await lucid.utxosAt(scriptAddress);
+  const utxo = await getUtxoByTxHash(txHashFromDesposit);
 
-const Datum = Data.Object({
-  lock_until: Data.BigInt, // this is POSIX time, you can check and set it here: https://www.unixtimestamp.com
-  owner: Data.String, // we can pass owner's verification key hash as byte array but also as a string
-  beneficiary: Data.String, // we can beneficiary's hash as byte array but also as a string
-});
+  if (utxo === undefined) throw new Error("UTxO not found");
 
-type Datum = Data.Static<typeof Datum>;
+  const unsignedTx = await withdrawFundTx(utxo);
 
-const currentTime = new Date().getTime();
+  const signedTx = await beneficiary_wallet.signTx(unsignedTx);
 
-// we filter out all the UTXOs by beneficiary and lock_until
-const utxos = scriptUtxos.filter((utxo) => {
-    let datum = Data.from<Datum>(
-      utxo.datum,
-      Datum,
-    );
-
-    return datum.beneficiary === beneficiaryPublicKeyHash &&
-      datum.lock_until <= currentTime;
-});
-
-if (utxos.length === 0) {
-  console.log("No redeemable utxo found. You need to wait a little longer...");
-  Deno.exit(1);
+  const txHash = await beneficiary_wallet.submitTx(signedTx);
+  console.log("txHash", txHash);
 }
 
-// we don't have any redeemer in our contract but it needs to be empty
-const redeemer = Data.empty();
+async function getUtxoByTxHash(txHash) {
+  const utxos = await blockchainProvider.fetchUTxOs(txHash);
+  if (utxos.length === 0) {
+    throw new Error("UTxO not found");
+  }
+  return utxos[0];
+}
 
-const txUnlock = await unlock(utxos, currentTime, { from: validator, using: redeemer });
-
-await lucid.awaitTx(txUnlock);
-
-console.log(`1 tADA recovered from the contract
-    Tx ID: ${txUnlock}
-    Redeemer: ${redeemer}
-`);
-
-// --- Supporting functions
-
-async function unlock(utxos, currentTime, { from, using }): Promise<TxHash> {
-  const laterTime = new Date(currentTime + 2 * 60 * 60 * 1000).getTime(); // add two hours (TTL: time to live)
-
-  const tx = await lucid
-    .newTx()
-    .collectFrom(utxos, using)
-    .addSigner(await lucid.wallet.address()) // this should be beneficiary address
-    .validFrom(currentTime)
-    .validTo(laterTime)
-    .attachSpendingValidator(from)
-    .complete();
-
-  const signedTx = await tx
-    .sign()
-    .complete();
-
-  return signedTx.submit();
+main();
 }
 ```
 
@@ -483,12 +469,12 @@ async function unlock(utxos, currentTime, { from, using }): Promise<TxHash> {
   As you imagine, we can run this script with the following incantation:
 
 ```
-deno run --allow-net --allow-read --allow-env vesting_unlock.ts
+node vesting_unlock.mjs
 ```
 
-</Callout>
+ </Callout>
 
-<Callout>
+<Callout type="info">
 ```
 This should be the projects structure. 
 ./vesting

--- a/src/pages/example--vesting/_meta.json
+++ b/src/pages/example--vesting/_meta.json
@@ -1,0 +1,3 @@
+{
+    "mesh": "with Mesh (JavaScript)"
+  }

--- a/src/pages/example--vesting/mesh.mdx
+++ b/src/pages/example--vesting/mesh.mdx
@@ -35,7 +35,6 @@ on the procedure.
 
 ```js filename="generate-credentials.mjs"
 import fs from 'node:fs';
-import 'dotenv/config';
 import {
   MeshWallet,
 } from "@meshsdk/core";
@@ -75,13 +74,15 @@ Let's write our time lock validator as `validators/vesting.ak`, starting with
 the definition of its interface (i.e. its datum's shape).
 
 ```aiken filename="validators/vesting.ak"
+use aiken/crypto.{VerificationKeyHash}
+
 pub type VestingDatum {
   /// POSIX time in milliseconds, e.g. 1672843961000
   lock_until: Int,
   /// Owner's credentials
-  owner: ByteArray,
+  owner: VerificationKeyHash,
   /// Beneficiary's credentials
-  beneficiary: ByteArray,
+  beneficiary: VerificationKeyHash,
 }
 ```
 ## Dependency
@@ -113,16 +114,26 @@ From there, lets define the `spend` validator itself.
 use cardano/transaction.{OutputReference, Transaction}
 use vodka_extra_signatories.{key_signed}
 use vodka_validity_range.{valid_after}
+use aiken/crypto.{VerificationKeyHash}
+
+pub type VestingDatum {
+  /// POSIX time in milliseconds, e.g. 1672843961000
+  lock_until: Int,
+  /// Owner's credentials
+  owner: VerificationKeyHash,
+  /// Beneficiary's credentials
+  beneficiary: VerificationKeyHash,
+}
 
 validator vesting {
+  // In principle, scripts can be used for different purpose (e.g. minting
+  // assets). Here we make sure it's only used when 'spending' from a eUTxO
   spend(
     datum_opt: Option<VestingDatum>,
     _redeemer: Data,
     _input: OutputReference,
     tx: Transaction,
   ) {
-    // In principle, scripts can be used for different purpose (e.g. minting
-    // assets). Here we make sure it's only used when 'spending' from a eUTxO
     expect Some(datum) = datum_opt
     or {
       key_signed(tx.extra_signatories, datum.owner),
@@ -177,7 +188,11 @@ Tests can use any function, constant or types defines in our module but beware,
 they cannot reference other tests!
 
 ```aiken filename="validators/vesting.ak"
+
+// ^^^ Code above is unchanged. ^^^
+
 // The mocktail module comes from the vodka dependency.
+// These dependencies should be added at the top of the file with the other imported modules. 
 use mocktail.{complete, invalid_before, mocktail_tx, required_signer_hash}
 use mocktail/virgin_key_hash.{mock_pub_key_hash}
 use mocktail/virgin_output_reference.{mock_utxo_ref}

--- a/src/pages/example--vesting/mesh.mdx
+++ b/src/pages/example--vesting/mesh.mdx
@@ -259,7 +259,7 @@ Let's see the validator in action!
 
 ### Setup
 First, let's install the dotenv package(https://www.npmjs.com/package/dotenv), which allows us to import our API key from a .env file. Next, we'll create a directory called common and, within it, a file named common.mjs. 
-This file will house utility functions used for both locking and unlocking assets. In this setup, we will import our [BLOCKFROST_API](https://blockfrost.dev/overview/getting-started) key from the .env file. 
+This file will house utility functions used for both locking and unlocking assets. In this setup, we will import our [BLOCKFROST_API](https://blockfrost.dev/overview/getting-started ) key from the .env file. 
 
 
 
@@ -302,6 +302,8 @@ export function getTxBuilder() {
   return new MeshTxBuilder({
     fetcher: blockchainProvider,
     submitter: blockchainProvider,
+    verbose: true, // <-- you can remove this if you dont want to see logs
+
   });
 }
 

--- a/src/pages/example--vesting/mesh.mdx
+++ b/src/pages/example--vesting/mesh.mdx
@@ -139,9 +139,9 @@ validator vesting {
 }
 ```
 
-The novelty here mostly lies in the check against a time period. In fact,
-transactions can have validity intervals that define from when and until when
-the transaction is considered valid. Validity bounds are checked by the ledger
+The key feature here is the time-based check, which is abstracted by 
+the valid_after function. In fact, transactions can have validity intervals that define from when
+and until the transaction is considered valid. Validity bounds are checked by the ledger
 prior to executing a script and only does so if the bounds are legit.
 
 This is meant to give scripts a notion of time, while preserving determinism
@@ -153,9 +153,14 @@ Note that because we don't control the upper-bound, it could very much be that
 this transaction is executed 30 years after the vesting delay. Yet, from the
 perspective of the vesting script, this is perfectly okay.
 
-See also how we annotate the redeemer to `Void` to indicate that it isn't used.
-We could also leave it unannotated but it's generally good to signal your intent
-explicitly. `Void` captures that pretty well.
+In Aiken, values that are not used directly can be prefixed with an underscore (`_`)
+to indicate they are intentionally ignored. In this validator, `_redeemer` and `_input` 
+are marked as unused inputs, making the intent clear and improving readability.  
+
+This practice is particularly helpful in contracts that may require multiple 
+parameters for different purposes, such as minting or spending, while not all
+parameters are always relevant to the current logic.
+
 
 ### Testing
 

--- a/src/pages/example--vesting/mesh.mdx
+++ b/src/pages/example--vesting/mesh.mdx
@@ -97,8 +97,8 @@ version = "0.1.1-beta"
 source = "github"
 
 ```
-Using Vodka as a dependency provides access to several utility functions designed for common contract validation needs. 
-In our vesting.ak file, we will use two specific functions from Vodka:
+Using vodka as a dependency provides access to several utility functions designed for common contract validation needs. 
+In our vesting.ak file, we will use two specific functions from vodka:
 
 - **`key_signed`**: Verifies that a specific key has signed the transaction. This ensures only authorized users can interact with the contract.
 
@@ -166,7 +166,7 @@ economy with some unforeseen bug, let's write a simple test. Aiken has builtin
 support for tests, which are very much like functions that takes no argument
 and must return a `Bool{:ak}`.
 
-In the test below, we leverage the **Mocktail** module provided by the **Vodka** dependency. 
+In the test below, we leverage the **mocktail** module provided by the **vodka** dependency. 
 This module offers various utility functions that simplify unit testing for our smart contracts. 
 
 

--- a/src/pages/example--vesting/mesh.mdx
+++ b/src/pages/example--vesting/mesh.mdx
@@ -162,26 +162,60 @@ explicitly. `Void` captures that pretty well.
 ### Testing
 
 Okay, now before deploying our contract in the wild and risking collapsing the
-economy with some unforeseen bug, let's write a few tests. Aiken has builtin
+economy with some unforeseen bug, let's write a simple test. Aiken has builtin
 support for tests, which are very much like functions that takes no argument
 and must return a `Bool{:ak}`.
+
+In the test below, we leverage the **Mocktail** module provided by the **Vodka** dependency. 
+This module offers various utility functions that simplify unit testing for our smart contracts. 
+
 
 Tests can use any function, constant or types defines in our module but beware,
 they cannot reference other tests!
 
 ```aiken filename="validators/vesting.ak"
-use aiken/interval.{Finite, Interval, IntervalBound, PositiveInfinity}
+// The mocktail module comes from the vodka dependency.
+use mocktail.{complete, invalid_before, mocktail_tx, required_signer_hash}
+use mocktail/virgin_key_hash.{mock_pub_key_hash}
+use mocktail/virgin_output_reference.{mock_utxo_ref}
 
-test must_start_after_succeed_when_lower_bound_is_after() {
-  must_start_after(interval.after(2), 1)
+type TestCase {
+  is_owner_signed: Bool,
+  is_beneficiary_signed: Bool,
+  is_lock_time_passed: Bool,
 }
 
-test must_start_after_succeed_when_lower_bound_is_equal() {
-  must_start_after(interval.after(2), 2)
+fn get_test_tx(test_case: TestCase) {
+  let TestCase { is_owner_signed, is_beneficiary_signed, is_lock_time_passed } =
+    test_case
+
+  mocktail_tx()
+    |> required_signer_hash(is_owner_signed, mock_pub_key_hash(1))
+    |> required_signer_hash(is_beneficiary_signed, mock_pub_key_hash(2))
+    |> invalid_before(is_lock_time_passed, 1672843961001)
+    |> complete()
 }
 
-test must_start_after_fail_when_lower_bound_is_before() {
-  !must_start_after(interval.after(2), 3)
+fn vesting_datum() {
+  VestingDatum {
+    lock_until: 1672843961000,
+    owner: mock_pub_key_hash(1),
+    beneficiary: mock_pub_key_hash(2),
+  }
+}
+
+test success_unlocking() {
+  let output_reference = mock_utxo_ref(0, 1)
+  let datum = Some(vesting_datum())
+  let test_case =
+    TestCase {
+      is_owner_signed: True,
+      is_beneficiary_signed: True,
+      is_lock_time_passed: True,
+    }
+
+  let tx = get_test_tx(test_case)
+  vesting.spend(datum, Void, output_reference, tx)
 }
 ```
 

--- a/src/pages/example--vesting/mesh.mdx
+++ b/src/pages/example--vesting/mesh.mdx
@@ -15,7 +15,6 @@ original owner.
 <br/>
 
 - [x] Writing non-trivial Aiken validators, with complex datums.
-- [x] Writing front-end transaction logic with Mesh.js
 - [x] Using more advanced Aiken features (type-aliases, pattern-matches)
 - [x] Writing unit tests using Aiken's built-in test framework
 - [x] Managing time on-chain through transaction validity ranges
@@ -36,7 +35,7 @@ Funds](/example--hello-world/end-to-end/lucid#getting-funds) in case you have an
 on the procedure.
 
 
-```mjs filename="generate-credentials.mjs"
+```js filename="generate-credentials.mjs"
 import fs from 'node:fs';
 import 'dotenv/config';
 import {
@@ -212,7 +211,7 @@ This file will house utility functions used for both locking and unlocking asset
 
 
 
-```mjs filename="common/common.mjs"
+```js filename="common/common.mjs"
 import 'dotenv/config';
 import {
   MeshWallet,
@@ -361,7 +360,7 @@ This file contains the function withdrawFundTx, which allows the beneficiary to 
 The function handles the necessary transaction construction and ensures that the funds can only be accessed after the specified conditions are met.
 
 
-```mjs filename="vesting_unlock.mjs"
+```js filename="vesting_unlock.mjs"
 import {
   deserializeAddress,
   deserializeDatum,
@@ -427,7 +426,7 @@ async function withdrawFundTx(vestingUtxo) {
 In this section, we define a `main` function that retrieves the transaction hash generated when we executed the `vesting_lock.mjs` file. 
 This hash will be used to fetch the corresponding UTxO (Unspent Transaction Output) for withdrawal.
 
-```mjs filename="vesting_unlock.mjs"
+```js filename="vesting_unlock.mjs"
 // ^^^ Code above is unchanged. ^^^
 
 async function main() {

--- a/src/pages/example--vesting/mesh.mdx
+++ b/src/pages/example--vesting/mesh.mdx
@@ -259,7 +259,7 @@ Let's see the validator in action!
 
 ### Setup
 First, let's install the dotenv package(https://www.npmjs.com/package/dotenv), which allows us to import our API key from a .env file. Next, we'll create a directory called common and, within it, a file named common.mjs. 
-This file will house utility functions used for both locking and unlocking assets. In this setup, we will import our BLOCKFROST_API key from the .env file. 
+This file will house utility functions used for both locking and unlocking assets. In this setup, we will import our [BLOCKFROST_API](https://blockfrost.dev/overview/getting-started) key from the .env file. 
 
 
 

--- a/src/pages/example--vesting/mesh.mdx
+++ b/src/pages/example--vesting/mesh.mdx
@@ -5,19 +5,17 @@ import { Callout } from "nextra-theme-docs";
 Armed with our recently acquired knowledge from the _Hello, World!_ contract,
 let's increase the difficulty and write a slightly more challenging one.
 
-A vesting contract is a common type of contract that allows to lock funds for a
-period of time, only to unlock them later -- once a specified time has passed.
-Usually, vesting contract defines a beneficiary who can be different from the
-original owner.
+A vesting contract is a common type of contract that allows funds to be locked for a period of time and unlocked later—once a specified time has passed. 
+Typically, a vesting contract defines a beneficiary who may be different from the original owner.
 
 ## Covered in this tutorial
 
 <br/>
 
 - [x] Writing non-trivial Aiken validators, with complex datums.
-- [x] Using more advanced Aiken features (type-aliases, pattern-matches)
-- [x] Writing unit tests using Aiken's built-in test framework
-- [x] Managing time on-chain through transaction validity ranges
+- [x] Using more advanced Aiken features (type-aliases, pattern-matches).
+- [x] Writing unit tests with Aiken and mocktail.
+- [x] Managing time on-chain through transaction validity ranges.
 
 <Callout type="info" emoji="📘">
   When encountering an unfamiliar syntax or concept, do not hesitate to refer to
@@ -87,7 +85,7 @@ pub type VestingDatum {
 }
 ```
 ## Dependency
-An additional dependency we will add to this project is [Vodka](https://github.com/sidan-lab/vodka).
+An additional dependency we will add to this project is [vodka](https://github.com/sidan-lab/vodka).
 To include vodka in our Aiken project, lets update our aiken.toml file to specify it as a dependency.
 
 ```aiken filename="aiken.toml"
@@ -166,7 +164,7 @@ economy with some unforeseen bug, let's write a simple test. Aiken has builtin
 support for tests, which are very much like functions that takes no argument
 and must return a `Bool{:ak}`.
 
-In the test below, we leverage the **mocktail** module provided by the **vodka** dependency. 
+In the test below, we also leverage the **mocktail** module provided by the **vodka** dependency. 
 This module offers various utility functions that simplify unit testing for our smart contracts. 
 
 
@@ -372,15 +370,12 @@ node vesting_lock.mjs
 </Callout>
 
 If all went according to plan, you should see the transaction identifier in the console.
-Make sure you copy this hash, you will need it in vestin_unlock.mjs file. 
+Make sure you copy this hash, you will need it in vesting_unlock.mjs file. 
 
 
 ### Unlocking funds from the contract
 
-Now we can use another wallet (beneficiary.sk). This wallet will be beneficiary
-wallet had been added into datum in the previous step (locking) as well.
-
-Finally, as a last step: we now want to spend the UTxO that is locked by our
+Now want to spend the UTxO that is locked by our
 `vesting` contract.
 
 To be valid, our transaction must meet one of two conditions:
@@ -392,7 +387,6 @@ To be valid, our transaction must meet one of two conditions:
 Let's make a new file `vesting_unlock.ts` and add the bits to unlock the funds in the contract. 
 This file contains the function withdrawFundTx, which allows the beneficiary to unlock funds from a vesting contract. 
 The function handles the necessary transaction construction and ensures that the funds can only be accessed after the specified conditions are met.
-
 
 ```js filename="vesting_unlock.mjs"
 import {


### PR DESCRIPTION
Hello, I was hoping to update the vesting example for the Aiken documentation. 
I removed Lucid. 

This example only uses 
Vanilla JS
Mesh.Js
Aiken. 

The core of this logic is heavily based on this example that can be found here. 
https://github.com/MeshJS/examples/blob/main/aiken-vesting/aiken-workspace/validators/vesting.ak

I introduced additional dependencies such as Vodka and dotenv. 
This example is in it's own subdirectory as can be seen here. 
<img width="260" alt="image" src="https://github.com/user-attachments/assets/25c3ff0a-ff09-45a5-b7f1-37a83bcdef04">

Also included the projects structure at the end to give user a good indication of what the structure of the project should look like. 
